### PR TITLE
Optimize Promise.delay with linked-list impl

### DIFF
--- a/lib/init.lua
+++ b/lib/init.lua
@@ -22,8 +22,8 @@ end
 --[[
 	Returns first value (success), and packs all following values.
 ]]
-local function packResult(...)
-	return ..., pack(select(2, ...))
+local function packResult(success, ...)
+	return success, select("#", ...), { ... }
 end
 
 --[[

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -258,7 +258,7 @@ function Promise._all(traceback, promises, amount)
 
 	-- We need to check that each value is a promise here so that we can produce
 	-- a proper error rather than a rejected promise with our error.
-	for i, promise in ipairs(promises) do
+	for i, promise in pairs(promises) do
 		if not Promise.is(promise) then
 			error((ERROR_NON_PROMISE_IN_LIST):format("Promise.all", tostring(i)), 3)
 		end
@@ -363,7 +363,7 @@ function Promise.allSettled(promises)
 
 	-- We need to check that each value is a promise here so that we can produce
 	-- a proper error rather than a rejected promise with our error.
-	for i, promise in ipairs(promises) do
+	for i, promise in pairs(promises) do
 		if not Promise.is(promise) then
 			error((ERROR_NON_PROMISE_IN_LIST):format("Promise.allSettled", tostring(i)), 2)
 		end
@@ -422,7 +422,7 @@ end
 function Promise.race(promises)
 	assert(type(promises) == "table", ERROR_NON_LIST:format("Promise.race"))
 
-	for i, promise in ipairs(promises) do
+	for i, promise in pairs(promises) do
 		assert(Promise.is(promise), (ERROR_NON_PROMISE_IN_LIST):format("Promise.race", tostring(i)))
 	end
 


### PR DESCRIPTION
### Main changes:
- Optimize Promise.delay queue
    - Utilizes a doubly-linked list implementation of a queue
    - More efficient than using an array in every case (see below)
- Allows `OnCancel` to `Disconnect()` the Heartbeat event.

The old queue/dequeue implementation used an array which:
- has items removed from the front (`table.remove(queue, 1)` O(n) each time)
    - this is especially bad in the main loop which could run multiple times in-a-row on a large array
    - corresponding time complexity with new implementation: O(1)
- uses table.insert() followed by table.sort() to add a new node (O(n log n))
    - corresponding time complexity with new implementation: O(n)
- has to lookup the index of the node being dequeued (O(n))
    - corresponding time complexity with new implementation: O(1)

### Minor changes:
- Always prefer `ipairs` to iterate over `promises` array
- Avoid pushing the call arguments stack to a table in `Promise.prototype.expect` and `Promise.prototype.await`
- Make `pack` and `packResult` 1 line each