### PR TITLE
Use pcall() on Promise.is when looking for the .andThen function

### DIFF
--- a/lib/init.lua
+++ b/lib/init.lua
@@ -471,7 +471,11 @@ function Promise.is(object)
 		return false
 	end
 
-	return type(object.andThen) == "function"
+	local ok, isPromise = pcall(function()
+		return type(object.andThen) == "function"
+	end)
+
+	return ok and isPromise
 end
 
 --[[

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -471,11 +471,20 @@ function Promise.is(object)
 		return false
 	end
 
-	local ok, isPromise = pcall(function()
-		return type(object.andThen) == "function"
-	end)
+	local objectMetatable = getmetatable(object)
 
-	return ok and isPromise
+	if objectMetatable == Promise then
+		-- The Promise came from this library.
+		return true
+	elseif objectMetatable == nil then
+		-- No metatable, but we should still chain onto tables with andThen methods
+		return type(object.andThen) == "function"
+	elseif type(objectMetatable) == "table" and type(rawget(objectMetatable, "andThen")) == "function" then
+		-- Maybe this came from a different or older Promise library.
+		return true
+	end
+
+	return false
 end
 
 --[[


### PR DESCRIPTION
Some tables might have strict metatables that error if a non-existant member is indexed, causing the chain to fail.

**Minimal reproduction sample:**

```lua
local Promise = require(--[[ Promise path here ]])
local noob = setmetatable({Health = 100}, {
    __index = function()
        error("You cant index non-existant stuff!")
    end
}

-- Promise will instantly reject
Promise.new(function(resolve, reject)
    resolve(noob)
end):andThen(function(monster)
    print(monster.Health)
end)
```