### PR TITLE
Fix default.project.json to allow usage as submodule

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,24 +1,6 @@
 {
 	"name": "lua-promise",
 	"tree": {
-		"$className": "DataModel",
-		"ServerScriptService": {
-			"$className": "ServerScriptService",
-			"Lib": {
-				"$path": "lib"
-			}
-		},
-		"TestService": {
-			"$className": "TestService",
-			"$properties": {
-				"ExecuteWithStudioRun": true
-			},
-			"TestEZ": {
-				"$path": "modules/testez/src"
-			},
-			"run": {
-				"$path": "runTests.server.lua"
-			}
-		}
+		"$path": "lib"
 	}
 }

--- a/default.project.json
+++ b/default.project.json
@@ -1,5 +1,5 @@
 {
-	"name": "promise",
+	"name": "Promise",
 	"tree": {
 		"$path": "lib"
 	}

--- a/default.project.json
+++ b/default.project.json
@@ -1,5 +1,5 @@
 {
-	"name": "lua-promise",
+	"name": "promise",
 	"tree": {
 		"$path": "lib"
 	}

--- a/test.project.json
+++ b/test.project.json
@@ -1,5 +1,5 @@
 {
-	"name": "lua-promise-test",
+	"name": "promise-test",
 	"tree": {
 		"$className": "DataModel",
 		"ServerScriptService": {

--- a/test.project.json
+++ b/test.project.json
@@ -1,5 +1,5 @@
 {
-	"name": "promise-test",
+	"name": "Promise-test",
 	"tree": {
 		"$className": "DataModel",
 		"ServerScriptService": {

--- a/test.project.json
+++ b/test.project.json
@@ -1,0 +1,24 @@
+{
+	"name": "lua-promise-test",
+	"tree": {
+		"$className": "DataModel",
+		"ServerScriptService": {
+			"$className": "ServerScriptService",
+			"Lib": {
+				"$path": "lib"
+			}
+		},
+		"TestService": {
+			"$className": "TestService",
+			"$properties": {
+				"ExecuteWithStudioRun": true
+			},
+			"TestEZ": {
+				"$path": "modules/testez/src"
+			},
+			"run": {
+				"$path": "runTests.server.lua"
+			}
+		}
+	}
+}


### PR DESCRIPTION
Currently, `default.project.json` is a test project. This renames it to `test.project.json` and sets the default project as one with no defined root, which can be nested in other projects.