### PR TITLE
Created a Installation page

### DIFF
--- a/lib/installation.md
+++ b/lib/installation.md
@@ -4,21 +4,7 @@ title: Installation
 
 # Installation
 
-## Quick Install
+### Method 1 - Manual
+You can navigate to [releases](https://github.com/evaera/roblox-lua-promise/releases) where you will be able to find recent published releases of the promise lib.
 
-To use promises quickly in your game can be achieved by using `HttpService` and `loadstring`. *(It's important you have both these enabled for it to properly work for this install method).*
-```lua
--- // Put this code at the top of the file
-local Http = game:GetService("HttpService")
-local url = "https://raw.githubusercontent.com/evaera/roblox-lua-promise/master/lib/init.lua"
-local Promise = loadstring(Http:GetAsync(url))()
-```
-## Copying Promise File \**recommended*
-
-This method of installation will be copying the actual promise script and putting it into a module script in your game.
-
-1. Go to the file on the github repo under [/roblox-lua-promise/lib/init.lua]("https://github.com/evaera/roblox-lua-promise/blob/master/lib/init.lua") and copy the contents of the file.
-
-2. Go into roblox studio and create a `ModuleScript`, paste the contents you previously copied into this file.
-
-3. Simply call the `require` function on the `ModuleScript` you created in a new `script`.
+To get the promise file all you need to do is select which version you want to use and click on `assets` and download the `zip` or the `roblox-lua-promise.lua` file, which you can put the contents into a ModuleScript.

--- a/lib/installation.md
+++ b/lib/installation.md
@@ -1,0 +1,24 @@
+---
+title: Installation
+---
+
+# Installation
+
+## Quick Install
+
+To use promises quickly in your game can be achieved by using `HttpService` and `loadstring`. *(It's important you have both these enabled for it to properly work for this install method).*
+```lua
+-- // Put this code at the top of the file
+local Http = game:GetService("HttpService")
+local url = "https://raw.githubusercontent.com/evaera/roblox-lua-promise/master/lib/init.lua"
+local Promise = loadstring(Http:GetAsync(url))()
+```
+## Copying Promise File \**recommended*
+
+This method of installation will be copying the actual promise script and putting it into a module script in your game.
+
+1. Go to the file on the github repo under [/roblox-lua-promise/lib/init.lua]("https://github.com/evaera/roblox-lua-promise/blob/master/lib/init.lua") and copy the contents of the file.
+
+2. Go into roblox studio and create a `ModuleScript`, paste the contents you previously copied into this file.
+
+3. Simply call the `require` function on the `ModuleScript` you created in a new `script`.


### PR DESCRIPTION
I simply added a markdown page for an installation guide providing 2 ways of installing.

A quick easy way with loadstring and HTTP service for people who just want to perform testing or the manual way to put it into a module script.

Looks like the following
![image](https://user-images.githubusercontent.com/34119605/90296125-b5fd8300-de58-11ea-8289-f9272b6b9389.png)
