### PR TITLE
(Promise.delay) Allow OnCancel to break out of the current loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Next]
 ### Fixed
-- Make `Promise.is` work with promises from old versions of the library
+- Make `Promise.is` work with promises from old versions of the library (#41)
+- Make `Promise.delay` properly break out of the current loop (#40)
 
 ## [3.0.0] - 2020-08-17
 ### Changed

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -715,7 +715,9 @@ do
 			if connection == nil then -- first is nil when connection is nil
 				first = node
 				connection = Promise._timeEvent:Connect(function()
-					while first.endTime <= Promise._getTime() do
+					local threadStart = Promise._getTime()
+
+					while first ~= nil and first.endTime < threadStart do
 						local current = first
 						first = current.next
 
@@ -727,7 +729,6 @@ do
 						end
 
 						current.resolve(Promise._getTime() - current.startTime)
-						if current.next == nil then return end -- kill this thread if there was no `first` before `resolve`
 					end
 				end)
 			else -- first is non-nil

--- a/lib/init.spec.lua
+++ b/lib/init.spec.lua
@@ -201,6 +201,21 @@ return function()
 			advanceTime(1)
 			expect(promise:getStatus()).to.equal(Promise.Status.Resolved)
 		end)
+
+		it("Should allow for delays to be cancelled", function()
+			local promise = Promise.delay(2)
+
+			Promise.delay(1):andThen(function()
+			    promise:cancel()
+			end)
+
+			expect(promise:getStatus()).to.equal(Promise.Status.Started)
+			advanceTime()
+			expect(promise:getStatus()).to.equal(Promise.Status.Started)
+			advanceTime(1)
+			expect(promise:getStatus()).to.equal(Promise.Status.Cancelled)
+			advanceTime(1)
+		end)
 	end)
 
 	describe("Promise.resolve", function()


### PR DESCRIPTION
Basically, this:
```lua
onCancel(function() -- I removed indentation for readability
-- remove node from queue
local next = node.next

if first == node then
	if next == nil then -- if `node` is the first and last
		connection:Disconnect() -- NOTICE THIS
		connection = nil
	else -- if `node` is `first` and not the last
		next.previous = nil -- not relevant today
	end
	first = next -- ALSO NOTICE THIS
...
```
Fails to break out of our heartbeat while loop:
```lua
connection = Promise._timeEvent:Connect(function()
	while first.endTime <= Promise._getTime() do
		local current = first
		first = current.next

		if first == nil then
			connection:Disconnect()
			connection = nil
		else
			first.previous = nil
		end

		current.resolve(Promise._getTime() - current.startTime)
		if current.next == nil then return end -- kill this thread if there was no `first` before `resolve`
	end
end)
```
Notice how the above loop can only be terminated by itself. This is wrong. It should also terminate when `OnCancel` sets `first` to `nil`. To fix this, we just add a check like `first ~= nil` in the loop condition.

The old code fails with the following repro:
```lua
local a

Promise.delay(2):andThen(function()
    print "Cancelling a"
    a:cancel()
end)

a = Promise.delay(2):andThen(function()
    print "Resolving a"
end)

print "Hello"
```

This PR also makes it so each heartbeat thread saves the time at which it started executing and can only resolve threads whose time has passed (i.e. `endTime < threadStart`). I believe this is the best idea for a few reasons:
  - In intensive situations, we are not going to try to keep resolving nodes if Lua execution time is large enough to meaningfully advance the clock. In such a case, it's probably better to not further eat up the Lua execution budget for that heartbeat thread and simply allow the next heartbeat to resolve subsequent node(s). That said, the likelihood that threadStart is somehow 0.0001 lower than the next node in the queue is pretty slim to begin with, therefore I don't think the previous functionality really had legitimate usefulness.
  - This solution eliminates the need to `return` or `break` out of our `while` loop because if we do have such a situation where the last node in the queue is being resolved and it adds another node to the queue during its resolution then `endTime < threadStart` will always be `false` for the heartbeat thread which needs to cancel.