### PR TITLE
Configure HttpEnabled when installing

### DIFF
--- a/lib/Installation.md
+++ b/lib/Installation.md
@@ -6,11 +6,18 @@ title: Installation
 
 ### Method 1 - Quick and Dirty
 
-1. Make sure HTTP requests are enabled in Game Settings
-2. In Roblox Studio, select the folder where you keep your third party modules / utilities.
-3. Run this in the command bar:
+1. In Roblox Studio, select the folder where you keep your third party modules / utilities.
+2. Run this in the command bar:
 
-<textarea readonly style="width: 100%" onclick="this.select()">local m = Instance.new("ModuleScript") m.Parent = game:GetService("Selection"):Get()[1] or game:GetService("ServerScriptService") m.Name = "Promise" m.Source = game:GetService("HttpService"):GetAsync("https://raw.githubusercontent.com/evaera/roblox-lua-promise/master/lib/init.lua") game:GetService("Selection"):Set({m})</textarea>
+<textarea readonly style="width: 100%" onclick="this.select()">local Http = game:GetService("HttpService")
+local HttpEnabled = Http.HttpEnabled
+Http.HttpEnabled = true
+local m = Instance.new("ModuleScript")
+m.Parent = game:GetService("Selection"):Get()[1] or game:GetService("ServerScriptService")
+m.Name = "Promise"
+m.Source = Http:GetAsync("https://raw.githubusercontent.com/evaera/roblox-lua-promise/master/lib/init.lua")
+game:GetService("Selection"):Set({m})
+Http.HttpEnabled = HttpEnabled</textarea>
 
 ### Method 2 - Manual
 


### PR DESCRIPTION
When using the command bar script, it first stores the current setting of HttpEnabled, sets it to true, adds the module, and sets it back to the previous value. This removes the step requiring the user to configure HttpEnabled within the Game Settings window.