### PR TITLE
Fixed wrongly directed link

### DIFF
--- a/lib/Installation.md
+++ b/lib/Installation.md
@@ -38,4 +38,4 @@ Using a package manager? The repository has a [`rotriever.toml`](https://github.
 
 ## Next
 
-Now, check out the [API reference](/lib)!
+Now, check out the [API reference](/roblox-lua-promise/lib/)!


### PR DESCRIPTION
Minor correction to the API reference, now should link to the correct webpage rather than to 404ed URL