### PR TITLE
feat: add and export Promise and PromiseLike types

### DIFF
--- a/lib/PromiseType.lua
+++ b/lib/PromiseType.lua
@@ -1,0 +1,23 @@
+export type PromiseLike<T> = {
+	andThen: (
+		PromiseLike<T>, -- self
+		((T) -> (nil | T | PromiseLike<T>))?, -- resolve
+		((any) -> (nil | T | PromiseLike<T>))? -- reject
+	) -> PromiseLike<T>,
+}
+
+export type Promise<T> = {
+	andThen: (
+		Promise<T>, -- self
+		((T) -> (nil | T | PromiseLike<T>))?, -- resolve
+		((any) -> (nil | T | PromiseLike<T>))? -- reject
+	) -> Promise<T>,
+
+	catch: (Promise<T>, ((any) -> (nil | T | PromiseLike<nil>))) -> Promise<T>,
+
+	onCancel: (Promise<T>, () -> ()?) -> boolean,
+
+	expect: (Promise<T>) -> T,
+}
+
+return {}

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -1397,3 +1397,7 @@ function Promise.fromEvent(event, predicate)
 end
 
 return Promise
+
+local PromiseTypeModule = require(script.PromiseType)
+export type Promise<T> = PromiseTypeModule.Promise<T>
+export type PromiseLike<T> = PromiseTypeModule.PromiseLike<T>


### PR DESCRIPTION
We've been using this library for handling Promises. We've also been using Luau to strongly type our Promises, so we wanted to see if we could merge the implementations of the Promise and PromiseLike types into the library.