### PR TITLE
Change Promise.delay into a task.delay wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+### Changed
+- `Promise.defer` now uses `task.defer` instead of waiting for the next `Heartbeat`. This has *different behavior*: while the deferred code will still run at the end of the frame, it runs alongside other Lua wake-ups which moves its position in the frame. Also, if you call `Promise.defer` from inside of an already-deferred thread/Promise, the code will run after your current thread/Promise is finished, during the same frame, rather than on the *next* frame.
+- `Promise.delay` now wraps `task.delay`. This shouldn't result in any noticeable behavior changes, but changes in behavior are still possible as we don't have direct control over how Roblox's task scheduler works.
+
 ## [4.0.0]
 ### Changed
 - `Promise:finally` no longer observes a rejection from a Promise. Calling `Promise:finally` is mostly transparent now.

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -376,9 +376,7 @@ function Promise.defer(executor)
 	local traceback = debug.traceback(nil, 2)
 	local promise
 	promise = Promise._new(traceback, function(resolve, reject, onCancel)
-		local connection
-		connection = Promise._timeEvent:Connect(function()
-			connection:Disconnect()
+		task.defer(function()
 			local ok, _, result = runExecutor(traceback, executor, resolve, reject, onCancel)
 
 			if not ok then

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -1026,10 +1026,10 @@ end
 --[=[
 	Returns a Promise that resolves after `seconds` seconds have passed. The Promise resolves with the actual amount of time that was waited.
 
-	This function is **not** a wrapper around `wait`. `Promise.delay` uses a custom scheduler which provides more accurate timing. As an optimization, cancelling this Promise instantly removes the task from the scheduler.
+	This function is a wrapper around `task.delay`.
 
 	:::warning
-	Passing `NaN`, infinity, or a number less than 1/60 is equivalent to passing 1/60.
+	Passing NaN, +Infinity, -Infinity, 0, or any other number less than the duration of a Heartbeat will cause the promise to resolve on the very next Heartbeat.
 	:::
 
 	```lua
@@ -1041,102 +1041,14 @@ end
 	@param seconds number
 	@return Promise<number>
 ]=]
-do
-	-- uses a sorted doubly linked list (queue) to achieve O(1) remove operations and O(n) for insert
-
-	-- the initial node in the linked list
-	local first
-	local connection
-
-	function Promise.delay(seconds)
-		assert(type(seconds) == "number", "Bad argument #1 to Promise.delay, must be a number.")
-		-- If seconds is -INF, INF, NaN, or less than 1 / 60, assume seconds is 1 / 60.
-		-- This mirrors the behavior of wait()
-		if not (seconds >= 1 / 60) or seconds == math.huge then
-			seconds = 1 / 60
-		end
-
-		return Promise._new(debug.traceback(nil, 2), function(resolve, _, onCancel)
-			local startTime = Promise._getTime()
-			local endTime = startTime + seconds
-
-			local node = {
-				resolve = resolve,
-				startTime = startTime,
-				endTime = endTime,
-			}
-
-			if connection == nil then -- first is nil when connection is nil
-				first = node
-				connection = Promise._timeEvent:Connect(function()
-					local threadStart = Promise._getTime()
-
-					while first ~= nil and first.endTime < threadStart do
-						local current = first
-						first = current.next
-
-						if first == nil then
-							connection:Disconnect()
-							connection = nil
-						else
-							first.previous = nil
-						end
-
-						current.resolve(Promise._getTime() - current.startTime)
-					end
-				end)
-			else -- first is non-nil
-				if first.endTime < endTime then -- if `node` should be placed after `first`
-					-- we will insert `node` between `current` and `next`
-					-- (i.e. after `current` if `next` is nil)
-					local current = first
-					local next = current.next
-
-					while next ~= nil and next.endTime < endTime do
-						current = next
-						next = current.next
-					end
-
-					-- `current` must be non-nil, but `next` could be `nil` (i.e. last item in list)
-					current.next = node
-					node.previous = current
-
-					if next ~= nil then
-						node.next = next
-						next.previous = node
-					end
-				else
-					-- set `node` to `first`
-					node.next = first
-					first.previous = node
-					first = node
-				end
-			end
-
-			onCancel(function()
-				-- remove node from queue
-				local next = node.next
-
-				if first == node then
-					if next == nil then -- if `node` is the first and last
-						connection:Disconnect()
-						connection = nil
-					else -- if `node` is `first` and not the last
-						next.previous = nil
-					end
-					first = next
-				else
-					local previous = node.previous
-					-- since `node` is not `first`, then we know `previous` is non-nil
-					previous.next = next
-
-					if next ~= nil then
-						next.previous = previous
-					end
-				end
-			end)
+function Promise.delay(seconds)
+	assert(type(seconds) == "number", "Bad argument #1 to Promise.delay, must be a number.")
+	local startTime = Promise._getTime()
+	return Promise._new(debug.traceback(nil, 2), function(resolve)
+		task.delay(seconds, function()
+			resolve(Promise._getTime() - startTime)
 		end)
-	end
+	end)
 end
 
 --[=[


### PR DESCRIPTION
This PR offloads the `Promise.delay` function onto the Roblox Engine's thread scheduler via `task.delay`
