### PR TITLE
Implement Luau types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.0.1]
+
+### Changed
+
+- Luau types have now been implemented into Promises.
+
 ## [4.0.0]
 ### Changed
 - `Promise:finally` no longer observes a rejection from a Promise. Calling `Promise:finally` is mostly transparent now.

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -2,7 +2,7 @@
 	An implementation of Promises similar to Promise/A+.
 ]]
 
-type Event = {Connect: (Event, callback: () -> ()) -> (),}
+type Event = {Connect: (Event, callback: (...any) -> ()) -> (),}
 
 type PromiseStatus = {
 	Started: string,

--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "evaera/promise"
 description = "Promise implementation for Roblox"
-version = "4.0.0"
+version = "4.0.1"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"


### PR DESCRIPTION
This PR fully implements Luau types into Promises. I've did quite a lot of testing and it works flawlessly, however I believe just a bit more testing should be done so that the Luau types implementation can be as solidified as possible.

Additional changes:

- Updated `CHANGELOG.md`
- Updated `wally.toml` file (You just need to publish the package)