### PR TITLE
Improve promise:expect() output in edge case

### DIFF
--- a/lib/init.lua
+++ b/lib/init.lua
@@ -1669,7 +1669,13 @@ end
 
 local function expectHelper(status, ...)
 	if status ~= Promise.Status.Resolved then
-		error((...) == nil and "Expected Promise rejected with no value." or (...), 3)
+		local message = (...)
+		error(
+			if (message == nil) or (message == "")
+				then "Expected Promise rejected with no value."
+				else message,
+			3
+		)
 	end
 
 	return ...


### PR DESCRIPTION
Hi. Provided we're over some silly past github drama, I think this is a well-made library and I  am using it in a production project.

I noticed an edge case with output when using `:expect()` on an asynchronous function that fails, producing a not-so-useful "Error Occurred: No Output From Lua" (ignore the line numbers here, as I'm using a forked version of the library with type annotations)

<img width="748" alt="image" src="https://user-images.githubusercontent.com/93293456/198107134-8cc228e8-917c-4e5e-ad3c-43017097507c.png">

The change in this PR produces a more useful error message in this edge case, though I'm still investigating why there was an empty error message encountered in the first place.