### PR TITLE
include only lib and default.project.json in wally.toml

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -5,6 +5,6 @@ version = "4.0.0"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
-include = ["lib", "default.project.json"]
+include = ["lib", "default.project.json", "LICENSE"]
 
 [dependencies]

--- a/wally.toml
+++ b/wally.toml
@@ -5,5 +5,6 @@ version = "4.0.0"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
+include = ["lib", "default.project.json"]
 
 [dependencies]


### PR DESCRIPTION
This will reduce the amount of junk downloaded to user's machines when using this library.