### PR TITLE
Fix callback errors in `retryWithDelay` and `retry`

### DIFF
--- a/lib/init.lua
+++ b/lib/init.lua
@@ -1851,7 +1851,7 @@ function Promise.retry(callback, times, ...)
 
 	local args, length = { ... }, select("#", ...)
 
-	return Promise.resolve(callback(...)):catch(function(...)
+	return Promise.try(callback, ...):catch(function(...)
 		if times > 0 then
 			return Promise.retry(callback, times - 1, unpack(args, 1, length))
 		else

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -1880,7 +1880,7 @@ function Promise.retryWithDelay(callback, times, seconds, ...)
 
 	local args, length = { ... }, select("#", ...)
 
-	return Promise.resolve(callback(...)):catch(function(...)
+	return Promise.try(callback, ...):catch(function(...)
 		if times > 0 then
 			Promise.delay(seconds):await()
 


### PR DESCRIPTION
Due to how it was structured with resolve, if the provided callback errored in `retryWithDelay`/`retry` it would not be inside of a promise, and therefor would not retry.