### PR TITLE
Fix type causing studio crash with cast to any

### DIFF
--- a/lib/init.lua
+++ b/lib/init.lua
@@ -712,7 +712,7 @@ function Promise.allSettled(promises)
 		return Promise.resolve({})
 	end
 
-	return Promise._new(debug.traceback(nil, 2), function(resolve, _, onCancel)
+	return (Promise._new :: any)(debug.traceback(nil, 2), function(resolve, _, onCancel)
 		-- An array to contain our resolved values from the given promises.
 		local fates = {}
 		local newPromises = {}


### PR DESCRIPTION
This is a workaround to a Roblox luau type checking issue that would cause Roblox Studio to crash.

[#102](https://github.com/evaera/roblox-lua-promise/issues/102)

Roblox dev forums discussion
https://devforum.roblox.com/t/roblox-studio-frequently-crashing-while-debugging/3130183

